### PR TITLE
user validator should use user['hashpw'] as byte

### DIFF
--- a/flask_sentinel/data.py
+++ b/flask_sentinel/data.py
@@ -105,7 +105,7 @@ class Storage(object):
         user = mongo.db.users.find_one({'username': username})
         if user and password:
             encoded_pw = password.encode('utf-8')
-            user_hash = user['hashpw'].encode('utf-8')
+            user_hash = user['hashpw']
             user = mongo.db.users.find_one({
                 'username': username,
                 'hashpw': bcrypt.hashpw(encoded_pw, user_hash)


### PR DESCRIPTION
you were using user["hashpw"] as it was a string (thus encoding it as utf-8 for use in bcrypt) but then you are querying the database over a byte