### PR TITLE
[bug-fix] autheticate_client

### DIFF
--- a/flask_sentinel/validator.py
+++ b/flask_sentinel/validator.py
@@ -6,9 +6,11 @@
     :copyright: (c) 2015 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
-from flask_oauthlib.provider import OAuth2RequestValidator
-
 from .data import Storage
+from flask_oauthlib.provider import OAuth2RequestValidator
+from flask_oauthlib.provider.oauth2 import log
+from flask_oauthlib.utils import decode_base64
+from oauthlib.common import to_unicode
 
 
 class MyRequestValidator(OAuth2RequestValidator):
@@ -20,3 +22,28 @@ class MyRequestValidator(OAuth2RequestValidator):
         self._usergetter = Storage.get_user
         self._tokengetter = Storage.get_token
         self._tokensetter = Storage.save_token
+
+    def authenticate_client(self, request, *args, **kwargs):
+
+        auth = request.headers.get('Authorization', None)
+        if auth:
+            try:
+                _, s = auth.split(' ')
+                client_id, client_secret = decode_base64(s).split(':')
+                client_id = to_unicode(client_id, 'utf-8')
+            except Exception as e:
+                log.debug('Authenticate client failed with exception: %r', e)
+                return False
+        else:
+            client_id = request.client_id
+
+        client = self._clientgetter(client_id)
+        if not client:
+            log.debug('Authenticate client failed, client not found.')
+            return False
+
+        if client.client_type == 'public':
+            return self.authenticate_client_id(client_id, request)
+        else:
+            return OAuth2RequestValidator.authenticate_client(
+                self, request, *args, **kwargs)


### PR DESCRIPTION
When flask-sentinel call flask-oauthlib's authenticate_client which validate client's secret key and the program raise a 500 Internal Server error. Override the autheticate_client can solve the problem.