### PR TITLE
fixed userhash encoding for python3

### DIFF
--- a/flask_sentinel/data.py
+++ b/flask_sentinel/data.py
@@ -105,7 +105,9 @@ class Storage(object):
         user = mongo.db.users.find_one({'username': username})
         if user and password:
             encoded_pw = password.encode('utf-8')
-            user_hash = user['hashpw'].encode('utf-8')
+            user_hash = (user['hashpw'].encode('utf-8')
+                         if hasattr(user['hashpw'], 'encode')
+                         else user['hashpw'])
             user = mongo.db.users.find_one({
                 'username': username,
                 'hashpw': bcrypt.hashpw(encoded_pw, user_hash)


### PR DESCRIPTION
Making the `userhash` work on Python3 with Python2 backward compatibility.
cf https://github.com/nicolaiarocci/flask-sentinel/pull/8#issuecomment-237471984